### PR TITLE
Fix multiple versions of pkgs being installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,15 @@ RUN git clone --depth 1 --branch challenge https://github.com/${DEV_SOURCE}/data
 FROM ${BASE_IMAGE}
 COPY --from=base /src /src
 
-RUN cd /src/data_port && python setup.py develop
+RUN python3.8 -m pip install --upgrade pip
+
+RUN cd /src/data_port && python3.8 -m pip install -e .
 
 COPY ./neuralpredictors /src/neuralpredictors
-RUN cd /src/neuralpredictors && python setup.py develop
+RUN cd /src/neuralpredictors && python3.8 -m pip install --no-use-pep517 -e .
 
 WORKDIR /project
 RUN mkdir /project/cascade
-COPY ./neural-prediction-challenge/cascade /project/cascade
-COPY ./neural-prediction-challenge/setup.py /project
-RUN python setup.py develop
+COPY ./cascade /project/cascade
+COPY ./setup.py /project
+RUN python3.8 -m pip install -e .


### PR DESCRIPTION
Multiple versions of numpy and scikit-image were installed because
`python setup.py develop` does not uninstall old versions before
installing a newer version. Using `pip install -e .` fixes this issue.

The `--no-use-pep517` option fixes the issue of not being able to import
neuralpredictors after installation. Without this option pip would install
it into /usr/lib/python3.8/site-packages/ which was not in PYTHONPATH.
With this option pip installs it into
/usr/local/lib/python3.8/dist-packages which is in PYTHONPATH. This
issue did not arise for the data_port package because unlike
neuralpredictors it does not have a pyproject.toml file.
